### PR TITLE
Fixed error when instance is invalid

### DIFF
--- a/lua_script_instance/src/lua_script_instance.cpp
+++ b/lua_script_instance/src/lua_script_instance.cpp
@@ -9,7 +9,9 @@ static int Get_impl(lua_State* L)
     dmScript::GetInstance(L);
     if (!dmScript::IsInstanceValid(L))
     {
-        DM_LUA_ERROR("Script instance is not set");
+       lua_pop(L,-1);
+       dmLogError("Script instance is not set");
+       return DM_LUA_ERROR("Script instance is not set");
     }
     return 1;
 }
@@ -19,7 +21,8 @@ static int Set_impl(lua_State* L)
     DM_LUA_STACK_CHECK(L, -1);
     if (!dmScript::IsInstanceValid(L))
     {
-        DM_LUA_ERROR("Instance is not valid");
+        dmLogError("Instance is not valid")
+        return DM_LUA_ERROR("Instance is not valid");
     }
     dmScript::SetInstance(L);
     return 0;


### PR DESCRIPTION
Fixed DM_LUA_ERROR

In current version, if script instance in invalid, you will get native exception.
Fixed how DM_LUA_ERROR worked.

1)Fixed Get_impl. In my project now it throw correct error. And engine not crashed.
2)Also make same fix for  Set_impl. Not sure but it also should worked. In my project i do not have problem with it.